### PR TITLE
Add the `SubwordIndices` trait.

### DIFF
--- a/finalfrontier/Cargo.toml
+++ b/finalfrontier/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.1.0"
 authors = ["Daniël de Kok <me@danieldk.eu>"]
 
 [dependencies]
+fnv = "1"
+
+[dev-dependencies]
+lazy_static = "1"
+maplit = "1"

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -1,2 +1,12 @@
+extern crate fnv;
+
+#[macro_use]
+#[cfg(test)]
+extern crate lazy_static;
+
+#[macro_use]
+#[cfg(test)]
+extern crate maplit;
+
 mod subword;
 pub use subword::NGrams;


### PR DESCRIPTION
This trait is used to extend `str` with the `subword_indices` method.
This method computes indices for all n-grams in the string, such the
indices index into the given number of buckets.