### PR TITLE
SIMD extensions

### DIFF
--- a/finalfrontier/src/util.rs
+++ b/finalfrontier/src/util.rs
@@ -7,7 +7,7 @@ pub use self::test::*;
 mod test {
     use ndarray::{ArrayView, Dimension};
 
-    fn close(a: f32, b: f32, eps: f32) -> bool {
+    pub fn close(a: f32, b: f32, eps: f32) -> bool {
         let diff = (a - b).abs();
         if diff > eps {
             return false;

--- a/finalfrontier/src/vec_simd.rs
+++ b/finalfrontier/src/vec_simd.rs
@@ -216,8 +216,8 @@ mod tests {
 
     #[test]
     fn scaled_add_f32x4_test() {
-        let mut u = Array1::random((100,), Range::new(-1.0, 1.0));
-        let v = Array1::random((100,), Range::new(-1.0, 1.0));
+        let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
+        let v = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 2.5);
         scaled_add_f32x4(u.view_mut(), v.view(), 2.5);
@@ -227,8 +227,8 @@ mod tests {
     #[test]
     #[cfg(feature = "avx-accel")]
     fn scaled_add_f32x8_test() {
-        let mut u = Array1::random((100,), Range::new(-1.0, 1.0));
-        let v = Array1::random((100,), Range::new(-1.0, 1.0));
+        let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
+        let v = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 2.5);
         scaled_add_f32x8(u.view_mut(), v.view(), 2.5);
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn scale_f32x4_test() {
-        let mut u = Array1::random((100,), Range::new(-1.0, 1.0));
+        let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scale_unvectorized(check.as_slice_mut().unwrap(), 2.);
         scale_f32x4(u.view_mut(), 2.);
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     #[cfg(feature = "avx-accel")]
     fn scale_f32x8_test() {
-        let mut u = Array1::random((100,), Range::new(-1.0, 1.0));
+        let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scale_unvectorized(check.as_slice_mut().unwrap(), 2.);
         scale_f32x8(u.view_mut(), 2.);

--- a/finalfrontier/src/vec_simd.rs
+++ b/finalfrontier/src/vec_simd.rs
@@ -7,6 +7,14 @@ use std::simd::f32x8;
 
 cfg_if! {
     if #[cfg(feature = "avx-accel")] {
+        /// Dot product: u · v
+        ///
+        /// This SIMD-vectorized function computes the dot product
+        /// (BLAS sdot).
+        pub fn dot(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
+            dot_f32x8(u, v)
+        }
+
         /// Scaling: u = au
         ///
         /// This function performs SIMD-vectorized scaling (BLAS sscal).
@@ -21,6 +29,14 @@ cfg_if! {
             scaled_add_f32x8(u, v, a)
         }
     } else {
+        /// Dot product: u · v
+        ///
+        /// This SIMD-vectorized function computes the dot product
+        /// (BLAS sdot).
+        pub fn dot(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
+            dot_f32x4(u, v)
+        }
+
         /// Scaling: u = au
         ///
         /// This function performs SIMD-vectorized scaling (BLAS sscal).
@@ -35,6 +51,71 @@ cfg_if! {
             scaled_add_f32x4(u, v, a)
         }
     }
+}
+
+#[allow(dead_code)]
+pub fn dot_f32x4(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
+    assert_eq!(u.len(), v.len());
+
+    let mut u = u
+        .as_slice()
+        .expect("Cannot apply SIMD instructions on non-contiguous data.");
+    let mut v = &v
+        .as_slice()
+        .expect("Cannot apply SIMD instructions on non-contiguous data.")[..u.len()];
+
+    let mut sums = f32x4::splat(0.0);
+
+    while u.len() >= 4 {
+        let a = f32x4::load_unaligned(u);
+        let b = f32x4::load_unaligned(v);
+
+        sums = sums + a * b;
+
+        u = &u[4..];
+        v = &v[4..];
+    }
+
+    sums.extract(0) + sums.extract(1) + sums.extract(2) + sums.extract(3) + dot_unvectorized(u, v)
+}
+
+#[cfg(feature = "avx-accel")]
+pub fn dot_f32x8(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
+    assert_eq!(u.len(), v.len());
+
+    let mut u = u
+        .as_slice()
+        .expect("Cannot apply SIMD instructions on non-contiguous data.");
+    let mut v = &v
+        .as_slice()
+        .expect("Cannot apply SIMD instructions on non-contiguous data.")[..u.len()];
+
+    let mut sums = f32x8::splat(0.0);
+
+    while u.len() >= 8 {
+        let a = f32x8::load_unaligned(u);
+        let b = f32x8::load_unaligned(v);
+
+        sums = sums + a * b;
+
+        u = &u[8..];
+        v = &v[8..];
+    }
+
+    sums.extract(0)
+        + sums.extract(1)
+        + sums.extract(2)
+        + sums.extract(3)
+        + sums.extract(4)
+        + sums.extract(5)
+        + sums.extract(6)
+        + sums.extract(7)
+        + dot_unvectorized(u, v)
+}
+
+pub fn dot_unvectorized(u: &[f32], v: &[f32]) -> f32 {
+    assert_eq!(u.len(), v.len());
+    u.iter().zip(v).map(|(&a, &b)| a * b).sum()
 }
 
 #[allow(dead_code)]
@@ -143,7 +224,8 @@ fn scale_f32x4(mut u: ArrayViewMut1<f32>, a: f32) {
 
 #[cfg(feature = "avx-accel")]
 fn scale_f32x8(mut u: ArrayViewMut1<f32>, a: f32) {
-    let mut u = u.as_slice_mut()
+    let mut u = u
+        .as_slice_mut()
         .expect("Cannot apply SIMD instructions on non-contiguous data.");
 
     let ax8 = f32x8::splat(a);
@@ -170,12 +252,15 @@ mod tests {
     use ndarray_rand::RandomExt;
     use rand::distributions::Range;
 
-    use util::{all_close, array_all_close};
+    use util::{all_close, array_all_close, close};
 
-    use super::{scale_f32x4, scale_unvectorized, scaled_add_f32x4, scaled_add_unvectorized};
+    use super::{
+        dot_f32x4, dot_unvectorized, scale_f32x4, scale_unvectorized, scaled_add_f32x4,
+        scaled_add_unvectorized,
+    };
 
     #[cfg(feature = "avx-accel")]
-    use super::{scale_f32x8, scaled_add_f32x8};
+    use super::{dot_f32x8, scale_f32x8, scaled_add_f32x8};
 
     #[test]
     fn add_unvectorized_test() {
@@ -204,6 +289,40 @@ mod tests {
         scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 1.0);
         scaled_add_f32x8(u.view_mut(), v.view(), 1.0);
         assert!(array_all_close(check.view(), u.view(), 1e-5));
+    }
+
+    #[test]
+    fn dot_f32x4_test() {
+        let u = Array1::random((102,), Range::new(-1.0, 1.0));
+        let v = Array1::random((102,), Range::new(-1.0, 1.0));
+        assert!(close(
+            dot_f32x4(u.view(), v.view()),
+            dot_unvectorized(u.as_slice().unwrap(), v.as_slice().unwrap()),
+            1e-5
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "avx-accel")]
+    fn dot_f32x8_test() {
+        let u = Array1::random((102,), Range::new(-1.0, 1.0));
+        let v = Array1::random((102,), Range::new(-1.0, 1.0));
+        assert!(close(
+            dot_f32x8(u.view(), v.view()),
+            dot_unvectorized(u.as_slice().unwrap(), v.as_slice().unwrap()),
+            1e-5
+        ));
+    }
+
+    #[test]
+    fn dot_unvectorized_test() {
+        let u = [1f32, -2f32, -3f32];
+        let v = [2f32, 4f32, -2f32];
+        let w = [-1f32, 3f32, 2.5f32];
+
+        assert!(close(dot_unvectorized(&u, &v), 0f32, 1e-5));
+        assert!(close(dot_unvectorized(&u, &w), -14.5f32, 1e-5));
+        assert!(close(dot_unvectorized(&v, &w), 5f32, 1e-5));
     }
 
     #[test]

--- a/finalfrontier/src/vec_simd.rs
+++ b/finalfrontier/src/vec_simd.rs
@@ -41,20 +41,33 @@ cfg_if! {
 fn scaled_add_f32x4(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
     assert_eq!(u.len(), v.len());
 
-    let mut u = u.as_slice_mut()
+    let mut u = u
+        .as_slice_mut()
         .expect("Cannot apply SIMD instructions on non-contiguous data.");
-    let mut v = v.as_slice()
-        .expect("Cannot apply SIMD instructions on non-contiguous data.");
+    let mut v = &v
+        .as_slice()
+        .expect("Cannot apply SIMD instructions on non-contiguous data.")[..u.len()];
 
-    let ax4 = f32x4::splat(a);
+    if a == 1f32 {
+        while u.len() >= 4 {
+            let mut ux4 = f32x4::load_unaligned(u);
+            let vx4 = f32x4::load_unaligned(v);
+            ux4 += vx4;
+            ux4.store_unaligned(u);
+            u = &mut { u }[4..];
+            v = &v[4..];
+        }
+    } else {
+        let ax4 = f32x4::splat(a);
 
-    while u.len() >= 4 {
-        let mut ux4 = f32x4::load_unaligned(u);
-        let vx4 = f32x4::load_unaligned(v);
-        ux4 += vx4 * ax4;
-        ux4.store_unaligned(u);
-        u = &mut { u }[4..];
-        v = &v[4..];
+        while u.len() >= 4 {
+            let mut ux4 = f32x4::load_unaligned(u);
+            let vx4 = f32x4::load_unaligned(v);
+            ux4 += vx4 * ax4;
+            ux4.store_unaligned(u);
+            u = &mut { u }[4..];
+            v = &v[4..];
+        }
     }
 
     scaled_add_unvectorized(u, v, a);
@@ -64,20 +77,33 @@ fn scaled_add_f32x4(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
 fn scaled_add_f32x8(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
     assert_eq!(u.len(), v.len());
 
-    let mut u = u.as_slice_mut()
+    let mut u = u
+        .as_slice_mut()
         .expect("Cannot apply SIMD instructions on non-contiguous data.");
-    let mut v = v.as_slice()
-        .expect("Cannot apply SIMD instructions on non-contiguous data.");
+    let mut v = &v
+        .as_slice()
+        .expect("Cannot apply SIMD instructions on non-contiguous data.")[..u.len()];
 
-    let ax8 = f32x8::splat(a);
+    if a == 1f32 {
+        while u.len() >= 8 {
+            let mut ux8 = f32x8::load_unaligned(u);
+            let vx8 = f32x8::load_unaligned(v);
+            ux8 += vx8;
+            ux8.store_unaligned(u);
+            u = &mut { u }[8..];
+            v = &v[8..];
+        }
+    } else {
+        let ax8 = f32x8::splat(a);
 
-    while u.len() >= 8 {
-        let mut ux8 = f32x8::load_unaligned(u);
-        let vx8 = f32x8::load_unaligned(v);
-        ux8 += vx8 * ax8;
-        ux8.store_unaligned(u);
-        u = &mut { u }[8..];
-        v = &v[8..];
+        while u.len() >= 8 {
+            let mut ux8 = f32x8::load_unaligned(u);
+            let vx8 = f32x8::load_unaligned(v);
+            ux8 += vx8 * ax8;
+            ux8.store_unaligned(u);
+            u = &mut { u }[8..];
+            v = &v[8..];
+        }
     }
 
     scaled_add_unvectorized(u, v, a);
@@ -86,14 +112,21 @@ fn scaled_add_f32x8(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
 fn scaled_add_unvectorized(u: &mut [f32], v: &[f32], a: f32) {
     assert_eq!(u.len(), v.len());
 
-    for i in 0..u.len() {
-        u[i] += v[i] * a;
+    if a == 1f32 {
+        for i in 0..u.len() {
+            u[i] += v[i];
+        }
+    } else {
+        for i in 0..u.len() {
+            u[i] += v[i] * a;
+        }
     }
 }
 
 #[allow(dead_code)]
 fn scale_f32x4(mut u: ArrayViewMut1<f32>, a: f32) {
-    let mut u = u.as_slice_mut()
+    let mut u = u
+        .as_slice_mut()
         .expect("Cannot apply SIMD instructions on non-contiguous data.");
 
     let ax4 = f32x4::splat(a);
@@ -143,6 +176,35 @@ mod tests {
 
     #[cfg(feature = "avx-accel")]
     use super::{scale_f32x8, scaled_add_f32x8};
+
+    #[test]
+    fn add_unvectorized_test() {
+        let u = &mut [1., 2., 3., 4., 5.];
+        let v = &[5., 3., 3., 2., 1.];
+        scaled_add_unvectorized(u, v, 1.0);
+        assert!(all_close(u, &[6.0, 5.0, 6.0, 6.0, 6.0], 1e-5));
+    }
+
+    #[test]
+    fn add_f32x4_test() {
+        let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
+        let v = Array1::random((102,), Range::new(-1.0, 1.0));
+        let mut check = u.clone();
+        scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 1.0);
+        scaled_add_f32x4(u.view_mut(), v.view(), 1.0);
+        assert!(array_all_close(check.view(), u.view(), 1e-5));
+    }
+
+    #[test]
+    #[cfg(feature = "avx-accel")]
+    fn add_f32x8_test() {
+        let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
+        let v = Array1::random((102,), Range::new(-1.0, 1.0));
+        let mut check = u.clone();
+        scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 1.0);
+        scaled_add_f32x8(u.view_mut(), v.view(), 1.0);
+        assert!(array_all_close(check.view(), u.view(), 1e-5));
+    }
 
     #[test]
     fn scaled_add_unvectorized_test() {

--- a/finalfrontier/src/vec_simd.rs
+++ b/finalfrontier/src/vec_simd.rs
@@ -14,7 +14,7 @@ cfg_if! {
             scale_f32x8(u, a)
         }
 
-        /// Scaled addition: *u = u + ay*
+        /// Scaled addition: *u = u + av*
         ///
         /// This function performs SIMD-vectorized scaled addition (BLAS saxpy).
         pub fn scaled_add(u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
@@ -28,7 +28,7 @@ cfg_if! {
             scale_f32x4(u, a)
         }
 
-        /// Scaled addition: *u = u + ay*
+        /// Scaled addition: *u = u + av*
         ///
         /// This function performs SIMD-vectorized scaled addition (BLAS saxpy).
         pub fn scaled_add(u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {


### PR DESCRIPTION
This pull request combines some improvements to the vec_simd module:

* Scaled additions are now faster, due to better length hints to the compiler and treating a scaling factor of 1 as a special case.
* Fix a small error in the documentation.
* In unit tests, don't use vectors that are a multiple of 4.
* Add a SIMD-vectorized dot product.