### PR TITLE
Compute discards based total # of corpus tokens.

### DIFF
--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -50,4 +50,4 @@ pub(crate) mod util;
 pub mod vec_simd;
 
 mod vocab;
-pub use vocab::{Token, Vocab, VocabBuilder};
+pub use vocab::{Type, Vocab, VocabBuilder};


### PR DESCRIPTION
Before the discards were computed based on the number of tokens after
removing tokens that are below the mincount threshold. Now we use the
overall number of tokens instead. This avoids that too many tokens get
discarded with high mincounts.

I have also renamed the 'Token' type (and related methods) to 'Type' to
avoid confusion with the new n_tokens methods.