### PR TITLE
Add type that performs stochastic gradient descent.

### DIFF
--- a/finalfrontier/src/hogwild.rs
+++ b/finalfrontier/src/hogwild.rs
@@ -1,4 +1,5 @@
 use std::cell::UnsafeCell;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use ndarray::{Array, ArrayView, ArrayViewMut, Axis, Dimension, Ix, Ix1, Ix2, Ix3, RemoveAxis};
@@ -118,11 +119,60 @@ pub type HogwildArray2<A> = HogwildArray<A, Ix2>;
 /// Three-dimensional Hogwild array.
 pub type HogwildArray3<A> = HogwildArray<A, Ix3>;
 
+/// Hogwild for arbitrary data types.
+///
+/// `Hogwild` subverts Rust's type system by allowing concurrent modification
+/// of values. This should only be used for data types that cannot end up in
+/// an inconsistent state due to data races. For arrays `HogwayArray` should
+/// be preferred.
+#[derive(Clone)]
+pub struct Hogwild<T>(Arc<UnsafeCell<T>>);
+
+impl<T> Default for Hogwild<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Hogwild(Arc::new(UnsafeCell::new(T::default())))
+    }
+}
+
+impl<T> Deref for Hogwild<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        let ptr = self.0.as_ref().get();
+        unsafe { &*ptr }
+    }
+}
+
+impl<T> DerefMut for Hogwild<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        let ptr = self.0.as_ref().get();
+        unsafe { &mut *ptr }
+    }
+}
+
+unsafe impl<T> Send for Hogwild<T> {}
+
+unsafe impl<T> Sync for Hogwild<T> {}
+
 #[cfg(test)]
 mod test {
     use ndarray::Array2;
 
-    use super::HogwildArray2;
+    use super::{Hogwild, HogwildArray2};
+
+    #[test]
+    pub fn hogwild_test() {
+        let mut a1: Hogwild<usize> = Hogwild::default();
+        let mut a2 = a1.clone();
+
+        *a1 = 1;
+        assert_eq!(*a2, 1);
+        *a2 = 2;
+        assert_eq!(*a1, 2);
+    }
 
     #[test]
     pub fn hogwild_array_test() {

--- a/finalfrontier/src/hogwild.rs
+++ b/finalfrontier/src/hogwild.rs
@@ -123,7 +123,7 @@ pub type HogwildArray3<A> = HogwildArray<A, Ix3>;
 ///
 /// `Hogwild` subverts Rust's type system by allowing concurrent modification
 /// of values. This should only be used for data types that cannot end up in
-/// an inconsistent state due to data races. For arrays `HogwayArray` should
+/// an inconsistent state due to data races. For arrays `HogwildArray` should
 /// be preferred.
 #[derive(Clone)]
 pub struct Hogwild<T>(Arc<UnsafeCell<T>>);

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -28,7 +28,7 @@ mod config;
 pub use config::{Config, LossType, ModelType};
 
 mod hogwild;
-pub use hogwild::{HogwildArray, HogwildArray1, HogwildArray2, HogwildArray3};
+pub use hogwild::{Hogwild, HogwildArray, HogwildArray1, HogwildArray2, HogwildArray3};
 
 mod loss;
 pub use loss::log_logistic_loss;
@@ -40,7 +40,7 @@ mod sampling;
 pub use sampling::{RangeGenerator, WeightedRangeGenerator, ZipfRangeGenerator};
 
 mod sgd;
-pub use sgd::NegativeSamplingSGD;
+pub use sgd::{NegativeSamplingSGD, SGD};
 
 mod subword;
 pub use subword::{NGrams, SubwordIndices};

--- a/finalfrontier/src/sgd.rs
+++ b/finalfrontier/src/sgd.rs
@@ -11,12 +11,12 @@ use {log_logistic_loss, Hogwild, RangeGenerator, TrainModel, ZipfRangeGenerator}
 /// This data type applies stochastic gradient descent on sentences.
 #[derive(Clone)]
 pub struct SGD<R> {
-    rng: R,
-    model: TrainModel,
-    sgd_impl: NegativeSamplingSGD<ZipfRangeGenerator<R>>,
-    n_tokens_processed: Hogwild<usize>,
     loss: Hogwild<f32>,
+    model: TrainModel,
     n_examples: Hogwild<usize>,
+    n_tokens_processed: Hogwild<usize>,
+    rng: R,
+    sgd_impl: NegativeSamplingSGD<ZipfRangeGenerator<R>>,
 }
 
 impl<R> SGD<R> {


### PR DESCRIPTION
At the moment, this always uses NegativeSamplingSGD. I haven't defined
a trait for SGD implementations yet, because we will have to see what
is necessary for hierarchical softmax SGD. Once I get to hierarchical
softmax models, we can make SGD use a trait rather than a specific
implementation.

As with NegativeLossSGD: no unit tests, since this pulls too much together.
I will add an integration test later that uses a small data set.