### PR TITLE
Directly use SIMD intrinsics.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 rust:
+  - stable
+  - beta
   - nightly
 matrix:
   allow_failures:

--- a/finalfrontier-utils/Cargo.toml
+++ b/finalfrontier-utils/Cargo.toml
@@ -11,6 +11,3 @@ indicatif = "0.9"
 memmap = "0.6"
 rand = "0.4"
 stdinout = "0.4"
-
-[features]
-avx-accel = ["finalfrontier/avx-accel"]

--- a/finalfrontier/Cargo.toml
+++ b/finalfrontier/Cargo.toml
@@ -16,6 +16,3 @@ zipf = "3"
 [dev-dependencies]
 lazy_static = "1"
 maplit = "1"
-
-[features]
-avx-accel = []

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 extern crate byteorder;
 
 #[macro_use]

--- a/finalfrontier/src/vec_simd.rs
+++ b/finalfrontier/src/vec_simd.rs
@@ -1,60 +1,71 @@
 use ndarray::{ArrayView1, ArrayViewMut1};
 
-use std::simd::f32x4;
+#[cfg(target_arch = "x86")]
+use std::arch::x86::*;
 
-#[cfg(feature = "avx-accel")]
-use std::simd::f32x8;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
 
+/// Dot product: u · v
+///
+/// This SIMD-vectorized function computes the dot product
+/// (BLAS sdot).
 cfg_if! {
-    if #[cfg(feature = "avx-accel")] {
-        /// Dot product: u · v
-        ///
-        /// This SIMD-vectorized function computes the dot product
-        /// (BLAS sdot).
+    if #[cfg(target_feature = "avx")] {
         pub fn dot(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
-            dot_f32x8(u, v)
+            unsafe { dot_f32x8(u, v) }
         }
-
-        /// Scaling: u = au
-        ///
-        /// This function performs SIMD-vectorized scaling (BLAS sscal).
-        pub fn scale(u: ArrayViewMut1<f32>, a: f32) {
-            scale_f32x8(u, a)
-        }
-
-        /// Scaled addition: *u = u + av*
-        ///
-        /// This function performs SIMD-vectorized scaled addition (BLAS saxpy).
-        pub fn scaled_add(u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
-            scaled_add_f32x8(u, v, a)
+    } else if #[cfg(target_feature = "sse")] {
+        pub fn dot(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
+            unsafe { dot_f32x4(u, v) }
         }
     } else {
-        /// Dot product: u · v
-        ///
-        /// This SIMD-vectorized function computes the dot product
-        /// (BLAS sdot).
         pub fn dot(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
-            dot_f32x4(u, v)
+            dot_unvectorized(u, v)
         }
+    }
+}
 
-        /// Scaling: u = au
-        ///
-        /// This function performs SIMD-vectorized scaling (BLAS sscal).
+/// Scaling: u = au
+///
+/// This function performs SIMD-vectorized scaling (BLAS sscal).
+cfg_if! {
+    if #[cfg(target_feature = "avx")] {
         pub fn scale(u: ArrayViewMut1<f32>, a: f32) {
-            scale_f32x4(u, a)
+            unsafe { scale_f32x8(u, a) }
         }
+    } else if #[cfg(target_feature = "sse")] {
+        pub fn scale(u: ArrayViewMut1<f32>, a: f32) {
+            unsafe { scale_f32x4(u, a) }
+        }
+    } else {
+        pub fn scale(u: ArrayViewMut1<f32>, a: f32) {
+            scale_unvectorized(u, a)
+        }
+    }
+}
 
-        /// Scaled addition: *u = u + av*
-        ///
-        /// This function performs SIMD-vectorized scaled addition (BLAS saxpy).
+/// Scaled addition: *u = u + av*
+///
+/// This function performs SIMD-vectorized scaled addition (BLAS saxpy).
+cfg_if! {
+    if #[cfg(target_feature = "avx")] {
         pub fn scaled_add(u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
-            scaled_add_f32x4(u, v, a)
+            unsafe { scaled_add_f32x8(u, v, a) }
+        }
+    } else if #[cfg(target_feature = "sse")] {
+        pub fn scaled_add(u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
+            unsafe { scaled_add_f32x4(u, v, a) }
+        }
+    } else {
+        pub fn scaled_add(u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
+            scaled_add_unvectorized(u, v, a)
         }
     }
 }
 
 #[allow(dead_code)]
-pub fn dot_f32x4(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
+unsafe fn dot_f32x4(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
     assert_eq!(u.len(), v.len());
 
     let mut u = u
@@ -64,23 +75,26 @@ pub fn dot_f32x4(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
         .as_slice()
         .expect("Cannot apply SIMD instructions on non-contiguous data.")[..u.len()];
 
-    let mut sums = f32x4::splat(0.0);
+    let mut sums = _mm_setzero_ps();
 
     while u.len() >= 4 {
-        let a = f32x4::load_unaligned(u);
-        let b = f32x4::load_unaligned(v);
+        let ux4 = _mm_loadu_ps(&u[0] as *const f32);
+        let vx4 = _mm_loadu_ps(&v[0] as *const f32);
 
-        sums = sums + a * b;
+        sums = _mm_add_ps(_mm_mul_ps(ux4, vx4), sums);
 
         u = &u[4..];
         v = &v[4..];
     }
 
-    sums.extract(0) + sums.extract(1) + sums.extract(2) + sums.extract(3) + dot_unvectorized(u, v)
+    sums = _mm_hadd_ps(sums, sums);
+    sums = _mm_hadd_ps(sums, sums);
+
+    _mm_cvtss_f32(sums) + dot_unvectorized(u, v)
 }
 
-#[cfg(feature = "avx-accel")]
-pub fn dot_f32x8(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
+#[cfg(target_feature = "avx")]
+unsafe fn dot_f32x8(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
     assert_eq!(u.len(), v.len());
 
     let mut u = u
@@ -90,27 +104,28 @@ pub fn dot_f32x8(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
         .as_slice()
         .expect("Cannot apply SIMD instructions on non-contiguous data.")[..u.len()];
 
-    let mut sums = f32x8::splat(0.0);
+    let mut sums = _mm256_setzero_ps();
 
     while u.len() >= 8 {
-        let a = f32x8::load_unaligned(u);
-        let b = f32x8::load_unaligned(v);
+        let ux8 = _mm256_loadu_ps(&u[0] as *const f32);
+        let vx8 = _mm256_loadu_ps(&v[0] as *const f32);
 
-        sums = sums + a * b;
+        // Future: support FMA?
+        // sums = _mm256_fmadd_ps(a, b, sums);
+
+        sums = _mm256_add_ps(_mm256_mul_ps(ux8, vx8), sums);
 
         u = &u[8..];
         v = &v[8..];
     }
 
-    sums.extract(0)
-        + sums.extract(1)
-        + sums.extract(2)
-        + sums.extract(3)
-        + sums.extract(4)
-        + sums.extract(5)
-        + sums.extract(6)
-        + sums.extract(7)
-        + dot_unvectorized(u, v)
+    sums = _mm256_hadd_ps(sums, sums);
+    sums = _mm256_hadd_ps(sums, sums);
+
+    // Sum sums[0..4] and sums[4..8].
+    let sums = _mm_add_ps(_mm256_castps256_ps128(sums), _mm256_extractf128_ps(sums, 1));
+
+    _mm_cvtss_f32(sums) + dot_unvectorized(u, v)
 }
 
 pub fn dot_unvectorized(u: &[f32], v: &[f32]) -> f32 {
@@ -119,7 +134,7 @@ pub fn dot_unvectorized(u: &[f32], v: &[f32]) -> f32 {
 }
 
 #[allow(dead_code)]
-fn scaled_add_f32x4(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
+unsafe fn scaled_add_f32x4(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
     assert_eq!(u.len(), v.len());
 
     let mut u = u
@@ -131,21 +146,21 @@ fn scaled_add_f32x4(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
 
     if a == 1f32 {
         while u.len() >= 4 {
-            let mut ux4 = f32x4::load_unaligned(u);
-            let vx4 = f32x4::load_unaligned(v);
-            ux4 += vx4;
-            ux4.store_unaligned(u);
+            let mut ux4 = _mm_loadu_ps(&u[0] as *const f32);
+            let vx4 = _mm_loadu_ps(&v[0] as *const f32);
+            ux4 = _mm_add_ps(ux4, vx4);
+            _mm_storeu_ps(&mut u[0] as *mut f32, ux4);
             u = &mut { u }[4..];
             v = &v[4..];
         }
     } else {
-        let ax4 = f32x4::splat(a);
+        let ax4 = _mm_set1_ps(a);
 
         while u.len() >= 4 {
-            let mut ux4 = f32x4::load_unaligned(u);
-            let vx4 = f32x4::load_unaligned(v);
-            ux4 += vx4 * ax4;
-            ux4.store_unaligned(u);
+            let mut ux4 = _mm_loadu_ps(&u[0] as *const f32);
+            let vx4 = _mm_loadu_ps(&v[0] as *const f32);
+            ux4 = _mm_add_ps(ux4, _mm_mul_ps(vx4, ax4));
+            _mm_storeu_ps(&mut u[0] as *mut f32, ux4);
             u = &mut { u }[4..];
             v = &v[4..];
         }
@@ -154,8 +169,8 @@ fn scaled_add_f32x4(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
     scaled_add_unvectorized(u, v, a);
 }
 
-#[cfg(feature = "avx-accel")]
-fn scaled_add_f32x8(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
+#[cfg(target_feature = "avx")]
+unsafe fn scaled_add_f32x8(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
     assert_eq!(u.len(), v.len());
 
     let mut u = u
@@ -167,21 +182,25 @@ fn scaled_add_f32x8(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
 
     if a == 1f32 {
         while u.len() >= 8 {
-            let mut ux8 = f32x8::load_unaligned(u);
-            let vx8 = f32x8::load_unaligned(v);
-            ux8 += vx8;
-            ux8.store_unaligned(u);
+            let mut ux8 = _mm256_loadu_ps(&u[0] as *const f32);
+            let vx8 = _mm256_loadu_ps(&v[0] as *const f32);
+
+            ux8 = _mm256_add_ps(ux8, vx8);
+
+            _mm256_storeu_ps(&mut u[0] as *mut f32, ux8);
             u = &mut { u }[8..];
             v = &v[8..];
         }
     } else {
-        let ax8 = f32x8::splat(a);
+        let ax8 = _mm256_set1_ps(a);
 
         while u.len() >= 8 {
-            let mut ux8 = f32x8::load_unaligned(u);
-            let vx8 = f32x8::load_unaligned(v);
-            ux8 += vx8 * ax8;
-            ux8.store_unaligned(u);
+            let mut ux8 = _mm256_loadu_ps(&mut u[0] as *const f32);
+            let vx8 = _mm256_loadu_ps(&v[0] as *const f32);
+
+            ux8 = _mm256_add_ps(ux8, _mm256_mul_ps(vx8, ax8));
+
+            _mm256_storeu_ps(&mut u[0] as *mut f32, ux8);
             u = &mut { u }[8..];
             v = &v[8..];
         }
@@ -205,35 +224,35 @@ fn scaled_add_unvectorized(u: &mut [f32], v: &[f32], a: f32) {
 }
 
 #[allow(dead_code)]
-fn scale_f32x4(mut u: ArrayViewMut1<f32>, a: f32) {
+unsafe fn scale_f32x4(mut u: ArrayViewMut1<f32>, a: f32) {
     let mut u = u
         .as_slice_mut()
         .expect("Cannot apply SIMD instructions on non-contiguous data.");
 
-    let ax4 = f32x4::splat(a);
+    let ax4 = _mm_set1_ps(a);
 
     while u.len() >= 4 {
-        let mut ux4 = f32x4::load_unaligned(u);
-        ux4 *= ax4;
-        ux4.store_unaligned(u);
+        let mut ux4 = _mm_loadu_ps(&u[0] as *const f32);
+        ux4 = _mm_mul_ps(ux4, ax4);
+        _mm_storeu_ps(&mut u[0] as *mut f32, ux4);
         u = &mut { u }[4..];
     }
 
     scale_unvectorized(u, a);
 }
 
-#[cfg(feature = "avx-accel")]
-fn scale_f32x8(mut u: ArrayViewMut1<f32>, a: f32) {
+#[cfg(target_feature = "avx")]
+unsafe fn scale_f32x8(mut u: ArrayViewMut1<f32>, a: f32) {
     let mut u = u
         .as_slice_mut()
         .expect("Cannot apply SIMD instructions on non-contiguous data.");
 
-    let ax8 = f32x8::splat(a);
+    let ax8 = _mm256_set1_ps(a);
 
     while u.len() >= 8 {
-        let mut ux8 = f32x8::load_unaligned(u);
-        ux8 *= ax8;
-        ux8.store_unaligned(u);
+        let mut ux8 = _mm256_loadu_ps(&mut u[0] as *const f32);
+        ux8 = _mm256_mul_ps(ux8, ax8);
+        _mm256_storeu_ps(&mut u[0] as *mut f32, ux8);
         u = &mut { u }[8..];
     }
 
@@ -259,7 +278,7 @@ mod tests {
         scaled_add_unvectorized,
     };
 
-    #[cfg(feature = "avx-accel")]
+    #[cfg(target_feature = "avx")]
     use super::{dot_f32x8, scale_f32x8, scaled_add_f32x8};
 
     #[test]
@@ -276,18 +295,18 @@ mod tests {
         let v = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 1.0);
-        scaled_add_f32x4(u.view_mut(), v.view(), 1.0);
+        unsafe { scaled_add_f32x4(u.view_mut(), v.view(), 1.0) };
         assert!(array_all_close(check.view(), u.view(), 1e-5));
     }
 
     #[test]
-    #[cfg(feature = "avx-accel")]
+    #[cfg(target_feature = "avx")]
     fn add_f32x8_test() {
         let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
         let v = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 1.0);
-        scaled_add_f32x8(u.view_mut(), v.view(), 1.0);
+        unsafe { scaled_add_f32x8(u.view_mut(), v.view(), 1.0) };
         assert!(array_all_close(check.view(), u.view(), 1e-5));
     }
 
@@ -296,19 +315,19 @@ mod tests {
         let u = Array1::random((102,), Range::new(-1.0, 1.0));
         let v = Array1::random((102,), Range::new(-1.0, 1.0));
         assert!(close(
-            dot_f32x4(u.view(), v.view()),
+            unsafe { dot_f32x4(u.view(), v.view()) },
             dot_unvectorized(u.as_slice().unwrap(), v.as_slice().unwrap()),
             1e-5
         ));
     }
 
     #[test]
-    #[cfg(feature = "avx-accel")]
+    #[cfg(target_feature = "avx")]
     fn dot_f32x8_test() {
         let u = Array1::random((102,), Range::new(-1.0, 1.0));
         let v = Array1::random((102,), Range::new(-1.0, 1.0));
         assert!(close(
-            dot_f32x8(u.view(), v.view()),
+            unsafe { dot_f32x8(u.view(), v.view()) },
             dot_unvectorized(u.as_slice().unwrap(), v.as_slice().unwrap()),
             1e-5
         ));
@@ -339,18 +358,18 @@ mod tests {
         let v = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 2.5);
-        scaled_add_f32x4(u.view_mut(), v.view(), 2.5);
+        unsafe { scaled_add_f32x4(u.view_mut(), v.view(), 2.5) };
         assert!(array_all_close(check.view(), u.view(), 1e-5));
     }
 
     #[test]
-    #[cfg(feature = "avx-accel")]
+    #[cfg(target_feature = "avx")]
     fn scaled_add_f32x8_test() {
         let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
         let v = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scaled_add_unvectorized(check.as_slice_mut().unwrap(), v.as_slice().unwrap(), 2.5);
-        scaled_add_f32x8(u.view_mut(), v.view(), 2.5);
+        unsafe { scaled_add_f32x8(u.view_mut(), v.view(), 2.5) };
         assert!(array_all_close(check.view(), u.view(), 1e-5));
     }
 
@@ -366,17 +385,17 @@ mod tests {
         let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scale_unvectorized(check.as_slice_mut().unwrap(), 2.);
-        scale_f32x4(u.view_mut(), 2.);
+        unsafe { scale_f32x4(u.view_mut(), 2.) };
         assert!(array_all_close(check.view(), u.view(), 1e-5));
     }
 
     #[test]
-    #[cfg(feature = "avx-accel")]
+    #[cfg(target_feature = "avx")]
     fn scale_f32x8_test() {
         let mut u = Array1::random((102,), Range::new(-1.0, 1.0));
         let mut check = u.clone();
         scale_unvectorized(check.as_slice_mut().unwrap(), 2.);
-        scale_f32x8(u.view_mut(), 2.);
+        unsafe { scale_f32x8(u.view_mut(), 2.) };
         assert!(array_all_close(check.view(), u.view(), 1e-5));
     }
 }


### PR DESCRIPTION
x86/x86_64 intrinsics are stabilized in Rust 1.27. However, std::simd is
not yet. These changes allow us to build against Rust stable again. Once
std::simd enters stable as well, we could switch to std::simd again.